### PR TITLE
Add ability to run b18 locally in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.4.6-apache
+
+RUN apt-get update && \
+    apt-get install -y libzip-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup needed php extensions
+RUN docker-php-ext-install mysqli pdo pdo_mysql zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.4'
+
+networks:
+  b18:
+
+volumes:
+  b18:
+    name: b18
+
+services:
+  b18:
+    container_name: b18
+    build: ./
+    networks:
+    - b18
+    ports:
+    - "8000:80"
+    volumes:
+    - "./:/var/www/html"
+    environment:
+      DB_HOST: db
+    depends_on:
+    - db
+  db:
+    container_name: db
+    image: mariadb:10.5.3
+    networks:
+    - b18
+    environment:
+      MYSQL_ROOT_PASSWORD: board18
+      MYSQL_DATABASE: board18
+      MYSQL_USER: board18
+      MYSQL_PASSWORD: board18
+    volumes:
+    - "./utility/board18db.txt:/docker-entrypoint-initdb.d/b18.sql"
+    - "b18:/var/lib/mysql"

--- a/php/config.php
+++ b/php/config.php
@@ -8,7 +8,7 @@
  * Copyright (c) 2013 Richard E. Price under the The MIT License.
  * A copy of this license can be found in the LICENSE.text file.
  */
-  define('DB_HOST', 'localhost');
+  define('DB_HOST', $_ENV['DB_HOST'] ?? 'localhost');
   define('DB_DATABASE', 'board18');
   define('DB_USER', 'board18');
   define('DB_PASSWORD', 'board18');

--- a/utility/config.php
+++ b/utility/config.php
@@ -8,7 +8,7 @@
  * Copyright (c) 2013 Richard E. Price under the The MIT License.
  * A copy of this license can be found in the LICENSE.text file.
  */
-  define('DB_HOST', 'localhost');
+  define('DB_HOST', $_ENV['DB_HOST'] ?? 'localhost');
   define('DB_DATABASE', 'board18');
   define('DB_USER', 'root');
   define('DB_PASSWORD', 'board18');


### PR DESCRIPTION
I realize that there is another PR open for this exact feature. A friend wanted to run b18 locally so I whipped this up without realizing it. Wanted to post it here for options etc.

1. Dockerfile for the php side of things just to install the mysql + zip libraries.
2. docker-compose.yml file is the basis for most of the things.
3. I edited the config files to support loading DB_HOST from an environment variable as well as the hardcoded default to avoid having to edit any files in docker images (keeps things simple).

No docs yet. To spin up just `docker-compose up` in the root. Creates a `b18` volume for data which can be removed with normal docker commands or `docker-compose down --volumes` in case you want to start with a clean db again.